### PR TITLE
(Issue #5) Replace mkrakowitzer-deploy with nanliu-staging

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,5 @@ fixtures:
     confluence: "#{source_dir}"
   repositories:
     deploy: "http://github.com/mkrakowitzer/puppet-deploy"
+    staging: "https://github.com/nanliu/puppet-staging"
     stdlib: "http://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
+---
 language: ruby
-rvm:
-  - 1.9.3
-script: "rake spec"
-env:
-  - PUPPET_VERSION=3.4.2
+bundler_args: --without system_tests
+script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email:
     - merritt@krakowitzer.com

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ rspecversion = ENV.key?('RSPEC_VERSION') ? "= #{ENV['RSPEC_VERSION']}" : ['>= 2.
 gem 'rake'
 gem 'puppet-lint'
 gem 'rspec', rspecversion
-gem 'rspec-puppet'
+gem 'rspec-puppet', "1.0.1"
 gem 'puppetlabs_spec_helper'
 gem 'puppet', puppetversion
 gem 'puppet-blacksmith'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,11 @@ class confluence (
   $gid          = undef,
 
   # Misc Settings
-  $downloadURL  = 'http://www.atlassian.com/software/confluence/downloads/binary/',
+  $downloadURL  = 'http://www.atlassian.com/software/confluence/downloads/binary',
+
+  # Choose whether to use nanliu-staging, or mkrakowitzer-deploy
+  # Defaults to nanliu-staging as it is puppetlabs approved.
+  $staging_or_deploy = 'staging',
 
   # Manage confluence server
   $manage_service = true,

--- a/spec/classes/confluence_install_deploy_spec.rb
+++ b/spec/classes/confluence_install_deploy_spec.rb
@@ -4,15 +4,16 @@ describe 'confluence' do
   describe 'confluence::install' do
     context 'default params' do
       let(:params) {{
-        :javahome    => '/opt/java',
-        :version     => '5.5.6',
-        :user        => 'confluence',
-        :group       => 'confluence',
-        :installdir  => '/opt/confluence',
-        :homedir     => '/home/confluence',
-        :format      => 'tar.gz',
-        :product     => 'confluence',
-        :downloadURL => 'http://www.atlassian.com/software/confluence/downloads/binary/',
+        :javahome          => '/opt/java',
+        :version           => '5.5.6',
+        :user              => 'confluence',
+        :group             => 'confluence',
+        :installdir        => '/opt/confluence',
+        :homedir           => '/home/confluence',
+        :format            => 'tar.gz',
+        :product           => 'confluence',
+        :downloadURL       => 'http://www.atlassian.com/software/confluence/downloads/binary/',
+	:staging_or_deploy => 'deploy',
         }}
       it { should contain_group('confluence') }
       it { should contain_user('confluence').with_shell('/bin/true') }
@@ -30,17 +31,18 @@ describe 'confluence' do
   
     context 'overwriting params' do
       let(:params) {{
-        :javahome    => '/opt/java',
-        :version     => '5.5.5',
-        :product     => 'confluence',
-        :format      => 'tar.gz',
-        :installdir  => '/opt/confluence',
-        :homedir     => '/random/homedir',
-        :user        => 'foo',
-        :group       => 'bar',
-        :uid         => 333,
-        :gid         => 444,
-        :downloadURL => 'http://downloads.atlassian.com/',
+        :javahome          => '/opt/java',
+        :version           => '5.5.5',
+        :product           => 'confluence',
+        :format            => 'tar.gz',
+        :installdir        => '/opt/confluence',
+        :homedir           => '/random/homedir',
+        :user              => 'foo',
+        :group             => 'bar',
+        :uid               => 333,
+        :gid               => 444,
+        :downloadURL       => 'http://downloads.atlassian.com/',
+	:staging_or_deploy => 'deploy',
         }}
         it { should contain_user('foo').with({
           'home'  => '/random/homedir',

--- a/spec/classes/confluence_install_staging_spec.rb
+++ b/spec/classes/confluence_install_staging_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper.rb'
+
+describe 'confluence' do
+  describe 'confluence::install' do
+    context 'default params' do
+      let(:params) {{
+        :javahome          => '/opt/java',
+        :version           => '5.5.6',
+        :user              => 'confluence',
+        :group             => 'confluence',
+        :installdir        => '/opt/confluence',
+        :homedir           => '/home/confluence',
+        :format            => 'tar.gz',
+        :product           => 'confluence',
+      }}
+
+      it { should contain_group('confluence') }
+
+      it { should contain_user('confluence').with_shell('/bin/true') }
+
+      it 'should deploy confluence 5.5.6 from tar.gz' do
+        should contain_staging__file("atlassian-confluence-5.5.6.tar.gz").with({
+          'source' => 'http://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-5.5.6.tar.gz',
+        })
+        should contain_staging__extract("atlassian-confluence-5.5.6.tar.gz").with({
+          'target'  => '/opt/confluence/atlassian-confluence-5.5.6',
+          'creates' => '/opt/confluence/atlassian-confluence-5.5.6/conf',
+          'strip'   => '1',
+          'user'    => 'confluence',
+          'group'   => 'confluence',
+        })
+      end
+
+      it 'should manage the confluence home directory' do
+        should contain_file('/home/confluence').with({
+          'ensure' => 'directory',
+          'owner' => 'confluence',
+          'group' => 'confluence'
+        })
+      end
+    end
+  
+    context 'overwriting params' do
+      let(:params) {{
+        :javahome          => '/opt/java',
+        :version           => '5.5.5',
+        :product           => 'confluence',
+        :format            => 'tar.gz',
+        :installdir        => '/opt/foo/confluence',
+        :homedir           => '/random/homedir',
+        :user              => 'foo',
+        :group             => 'bar',
+        :uid               => 333,
+        :gid               => 444,
+        :downloadURL       => 'http://downloads.atlassian.com',
+      }}
+
+      it { should contain_user('foo').with({
+        'home'  => '/random/homedir',
+        'shell' => '/bin/true',
+        'uid'   => 333,
+        'gid'   => 444
+      })}
+
+      it { should contain_group('bar') }
+
+      it 'should deploy confluence 5.5.5 from tar.gz' do
+        should contain_staging__file("atlassian-confluence-5.5.5.tar.gz").with({
+          'source' => 'http://downloads.atlassian.com/atlassian-confluence-5.5.5.tar.gz',
+        })
+        should contain_staging__extract("atlassian-confluence-5.5.5.tar.gz").with({
+          'target'  => '/opt/foo/confluence/atlassian-confluence-5.5.5',
+          'creates' => '/opt/foo/confluence/atlassian-confluence-5.5.5/conf',
+          'strip'   => '1',
+          'user'    => 'foo',
+          'group'   => 'bar',
+        })
+      end 
+      it 'should manage the confluence home directory' do
+        should contain_file('/random/homedir').with({
+          'ensure' => 'directory',
+          'owner' => 'foo',
+          'group' => 'bar'
+        })
+      end
+    end
+  end
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,8 +1,6 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 
-proxyurl = ENV['http_proxy'] if ENV['http_proxy']
-
 unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
     foss_opts = { :default_action => 'gem_install' }
@@ -39,7 +37,6 @@ RSpec.configure do |c|
       end
       on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','puppetlabs-postgresql'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module','install','yguenane-repoforge'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','mkrakowitzer-deploy'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','puppetlabs-java'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','nanliu-staging'), { :acceptable_exit_codes => [0,1] }


### PR DESCRIPTION
Replace mkrakowitzer-deploy with nanliu-staging as the default to deploy
the installation files. nanlui-staging is puppetlabs approved and is
therefore preferred.